### PR TITLE
chore: remove os dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "peerDependencies": {
     "karma": ">=0.9"
   },
-  "os": [
-    "win32"
-  ],
   "license": "MIT",
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
This pull request removes the os dependency from the `package.json` file. This is helpful when working on a project with team members which have different operating systems. Now one can have all browser plugins for karma in the `package.json` without getting a npm error when running `npm install`.
