### PR TITLE
Support 64-bit IE and isolate environment.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,38 @@
-var IEBrowser = function(baseBrowserDecorator) {
+var fs = require('fs');
+
+var IEBrowser = function(baseBrowserDecorator, args) {
   baseBrowserDecorator(this);
+
+  args = args || {};
+  var flags = args.flags || [];
+
+  this._getOptions = function(url) {
+    return [
+      '-extoff',
+      '-private'
+    ].concat(flags, [url]);
+  }
 };
+
+function getInternetExplorerExe() {
+    var suffix = '\\Internet Explorer\\iexplore.exe',
+        prefixes = [process.env['PROGRAMW6432'], process.env['PROGRAMFILES(X86)'], process.env['PROGRAMFILES']],
+        prefix, i;
+
+    for (i = 0; i < prefixes.length; i++) {
+        prefix = prefixes[i];
+        if (prefix && fs.existsSync(prefix + suffix)) {
+            return prefix + suffix;
+        }
+    }
+
+    throw new Error("Internet Explorer not found");
+}
 
 IEBrowser.prototype = {
   name: 'IE',
   DEFAULT_CMD: {
-    win32: process.env.ProgramFiles + '\\Internet Explorer\\iexplore.exe'
+    win32: getInternetExplorerExe()
   },
   ENV_CMD: 'IE_BIN'
 };


### PR DESCRIPTION
This patch tries to auto-detect 64-bit IE by checking for the appropriate environment variables. It also
improves reliability of the tests by disabling extensions and using "InPrivate" mode to ignore existing user data.

Addresses #1, #3, #4, and possibly #8.
