### PR TITLE
fix: fail when launcher is called if IE is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,6 @@ function getInternetExplorerExe() {
       return prefix + suffix;
     }
   }
-
-  throw new Error('Internet Explorer not found');
 }
 
 IEBrowser.prototype = {


### PR DESCRIPTION
instead of failing as soon as the plug-in is loaded
closes #14
