### PR TITLE
chore: disable `-extoff` flag to be set by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ customLaunchers: {
 ```
 See [Specifying legacy document modes] on MSDN.
 
+### Running IE in "No add-ons mode"
+
+Please note that since **v0.2.0** default behaviour of launching Internet Explorer has changed.
+Now it runs using system-wide configuration (uses same settings as if you would run it manually) but prior to **v0.2.0** it was spawned with `-extoff` flag set explicitly, so all extensions were disabled.
+
+If you expect the same behaviour as it was before **v0.2.0**, Karma configuration should be slightly changed:
+- create new `customLauncher` configuration (`IE_no_addons` is used in an example below) with custom flags (in our case it is `-extoff` only)
+- browser `IE` in `browsers` field should be replaced with your new custom launcher name
+```js
+  browsers: ['IE_no_addons'],
+  customLaunchers: {
+    IE_no_addons: {
+      base:  'IE',
+      flags: ['-extoff']
+    }
+  }
+```
+
+See [IE Command-Line Options] on MSDN.
+
 ----
 
 For more information on Karma see the [homepage].
@@ -56,3 +76,4 @@ For more information on Karma see the [homepage].
 
 [homepage]: http://karma-runner.github.com
 [Specifying legacy document modes]: http://msdn.microsoft.com/en-us/library/ie/jj676915(v=vs.85).aspx
+[IE Command-Line Options]: https://msdn.microsoft.com/en-us/library/hh826025(v=vs.85).aspx

--- a/index.js
+++ b/index.js
@@ -82,9 +82,7 @@ var IEBrowser = function(baseBrowserDecorator, logger, args) {
     delete urlObj.search; //url.format does not want search attribute
     url = urlformat(urlObj);
 
-    return [
-      '-extoff'
-    ].concat(flags, [url]);
+    return flags.concat(url);
   };
 
   var baseOnProcessExit = this._onProcessExit;

--- a/test/launcher.spec.coffee
+++ b/test/launcher.spec.coffee
@@ -63,16 +63,11 @@ describe 'launcher', ->
         launcher = injector.get('launcher:IE')
         launcher._getOptions('url')
 
-    it 'should add -extoff', (done) ->
-      options = getOptions('url', module)
-      expect(options[0]).to.equal '-extoff'
-      done()
-
     it 'should include args.flags', (done) ->
       module.args[1] = {flags: ['-flag1', '-flag2']}
       options = getOptions('url', module)
-      expect(options[1]).to.equal '-flag1'
-      expect(options[2]).to.equal '-flag2'
+      expect(options[0]).to.equal '-flag1'
+      expect(options[1]).to.equal '-flag2'
       done()
 
     it 'should return url as the last flag', (done) ->


### PR DESCRIPTION
Resolves #27

In many cases IE add-ons are essential for proper application functioning (i.e., parsing XML via [MSXML](https://msdn.microsoft.com/en-us/library/ms763742%28v=vs.85%29.aspx)), so explicitly setting `-extoff` flag makes impossible to run test suites for such apps.

If someone requires all add-ons to be switched off by the nature of the case (which is less likely but possible), it can be easily achieved by specifying that flag in `customLaunchers` section of Karma config though:
```javascript
config.set({
  browsers: ['IE_no_addons'],
  // ...
  customLaunchers: {
    IE_no_addons: {
      base:  'IE',
      flags: ['-extoff']
    }
  }
});
```

Feel free to comment :wink: 