### PR TITLE
Fixed wmic path (now uses absolute path instead of relying on PATH)

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function IEBrowser (baseBrowserDecorator, logger, args) {
     var scodef = 'SCODEF:' + pid
 
     // wmic.exe : http://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
-    var wmic = 'wmic.exe Path win32_Process ' +
+    var wmic = 'C:\\Windows\\system32\\wbem\\wmic.exe Path win32_Process ' +
       'where "Name=\'' + PROCESS_NAME + "' and " +
       "CommandLine Like '%" + scodef + '%\'" call Terminate'
 

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -175,7 +175,7 @@ describe('launcher', function () {
     it('should call wmic with process ID', function (done) {
       onProcessExit()
       expect(childProcessCmd).to.equal(
-        'wmic.exe Path win32_Process where ' +
+        'C:\\Windows\\system32\\wbem\\wmic.exe Path win32_Process where ' +
         '"Name=\'iexplore.exe\' and CommandLine Like \'%SCODEF:10%\'" call Terminate'
       )
       done()


### PR DESCRIPTION
Like the title suggests, I've fixed the path used to kill the extra IE process. Similar work had been done on #29 but the PR was never merged.