### PR TITLE
_onProcessExit is missing "signal" parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,11 +98,11 @@ function IEBrowser (baseBrowserDecorator, logger, args) {
   }
 
   var baseOnProcessExit = this._onProcessExit
-  this._onProcessExit = function (code, errorOutput) {
+  this._onProcessExit = function (code, signal, errorOutput) {
     var pid = this._process.pid
     killExtraIEProcess(pid, function () {
       if (baseOnProcessExit) {
-        baseOnProcessExit(code, errorOutput)
+        baseOnProcessExit(code, signal, errorOutput)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-ie-launcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Karma plugin. Launcher for Internet Explorer.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In recent versions of Karma, `_onProcessExit` has a third parameter called `signal`, in between `code` & `errorOutput`.

`karma-ie-launcher` is missing this parameter.